### PR TITLE
task: Return client secret in resp

### DIFF
--- a/authserver/api/client.py
+++ b/authserver/api/client.py
@@ -210,7 +210,11 @@ class ClientResource(Resource):
             db.session.rollback()
             exception_name = type(e).__name__
             return self.response_handler.exception_response(exception_name)
-        return self.response_handler.successful_update_response('Client', client_id)
+        return self.response_handler.custom_response(
+            code=200,
+            status='OK',
+            messages={'client_secret': new_secret}
+        )
 
     def _delete_secret(self, client_id):
         new_secret = None


### PR DESCRIPTION
This PR adds more precise response messaging when updating the client secret, i.e., the message includes the newly created secret.

Handles part of https://github.com/brighthive/facet/issues/42