### PR TITLE
Session clear

### DIFF
--- a/authserver/api/oauth2.py
+++ b/authserver/api/oauth2.py
@@ -28,6 +28,14 @@ def current_user():
         return User.query.get(uid)
     return None
 
+def clear_user_session():
+    '''
+    This function clears the Authserver user session.
+    The `authorize` endpoint calls it, immediately before the redirect, since
+    the authorized user no longer needs the Authserver UI.
+    '''
+    if 'id' in session:
+        session.pop('id')
 
 @oauth2_bp.route('/authorize', methods=['GET', 'POST'])
 def authorize():
@@ -48,6 +56,9 @@ def authorize():
         grant_user = user
     else:
         grant_user = None
+
+    clear_user_session()
+
     return authorization.create_authorization_response(grant_user=grant_user)
 
 

--- a/tests/api/test_login.py
+++ b/tests/api/test_login.py
@@ -1,0 +1,32 @@
+import json
+from flask import Response, session
+
+import pytest
+from unittest.mock import patch
+from urllib.parse import urlencode
+from expects import expect, equal, be_empty
+
+class TestLogin:
+    def test_session_clear_after_confirm(self, client, user):
+        with client as client:
+            # `session_transaction` provides a way to simulate a call to the current SecureCookieSession, allowing us to check or modify its value (before and after making an HTTP request) 
+            # https://flask.palletsprojects.com/en/0.12.x/testing/#accessing-and-modifying-sessions
+            # https://github.com/pytest-dev/pytest-flask/issues/69 
+            with client.session_transaction() as session:
+                # Update the SecureCookieSession
+                session["id"] = user.id
+
+            with client.session_transaction() as session:
+                # Sanity check! Assert that SecureCookieSession has the correct key value
+                expect(session["id"]).to(equal(user.id))
+
+            form_data = urlencode({'confirm': 'on'})
+            response: Response = client.post(
+                '/oauth/authorize', 
+                data=form_data, 
+                content_type="application/x-www-form-urlencoded"
+            )
+
+            with client.session_transaction() as session:
+                # Assert that `authorize` cleared the session before redirecting
+                expect(session).to(be_empty)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,6 @@ def data_trust(app):
 @pytest.fixture(scope='session')
 def user(app, data_trust):
     with app.app_context():
-        # dt = DataTrust.query.filter_by(data_trust_name="trusty trust").first()
         user_data = {
             'username': 'test-user-1',
             'email_address': 'demo@me.com',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,41 @@ from flask_migrate import upgrade
 from authserver import create_app
 from authserver.utilities import PostgreSQLContainer
 from authserver.config import ConfigurationFactory
+from authserver.db import db
+from authserver.db import db, DataTrust, User
 
+
+@pytest.fixture(scope='session')
+def data_trust(app):
+    with app.app_context():
+        data_trust = DataTrust(**{'data_trust_name': "trusty trust"})
+        db.session.add(data_trust)
+        db.session.commit()
+        
+        new_data_trust = DataTrust.query.filter_by(data_trust_name="trusty trust").first()
+    return new_data_trust
+
+@pytest.fixture(scope='session')
+def user(app, data_trust):
+    with app.app_context():
+        # dt = DataTrust.query.filter_by(data_trust_name="trusty trust").first()
+        user_data = {
+            'username': 'test-user-1',
+            'email_address': 'demo@me.com',
+            'password': 'password',
+            'firstname': 'David',
+            'lastname': 'Michaels',
+            'organization': 'BrightHive',
+            'telephone': '304-555-1234',
+            'data_trust_id': data_trust.id,
+        }
+        user = User(**user_data)
+        db.session.add(user)
+        db.session.commit()
+
+        new_user = User.query.filter_by(username="test-user-1").first()
+    
+    return user
 
 @pytest.fixture(scope='session')
 def client():


### PR DESCRIPTION
# Overview

This PR adds logic that clears the session after a user "confirms" (e.g., confirms that Facet can act on their behalf). We do this, because the authserver UI no longer provides a service to the user and hence the session need not persist. 

Closes #15 

### On tests

I added a simple test that looks at the session before and after POSTing to the authorize endpoint with form data. (Note! This was trickier to do then the test suggests.)

[I also added some fixtures for populating the database](https://github.com/brighthive/authserver/pull/16/files#diff-484462fced51d1a06b1d93b4a44dd535R13) which can hopefully serve future unit tests.