### PR TITLE
fix: Account for client_id_issued_at 

### DIFF
--- a/authserver/api/client.py
+++ b/authserver/api/client.py
@@ -5,14 +5,15 @@ An API for registering clients with Auth Server.
 """
 
 import json
+import time
 from datetime import datetime
 from uuid import uuid4
 
 from flask import Blueprint
 from flask_restful import Api, Resource, request
-from werkzeug.security import gen_salt
 from webargs import fields, validate
 from webargs.flaskparser import use_args, use_kwargs
+from werkzeug.security import gen_salt
 
 from authserver.db import (DataTrust, DataTrustSchema, OAuth2Client,
                            OAuth2ClientSchema, Role, User, UserSchema, db)
@@ -114,6 +115,8 @@ class ClientResource(Resource):
                         except Exception as e:
                             client_metadata[k] = v
             client.set_client_metadata(client_metadata)
+            client.client_id_issued_at = int(time.time())
+
             db.session.add(client)
             db.session.commit()
         except Exception as e:

--- a/authserver/db/models/models.py
+++ b/authserver/db/models/models.py
@@ -227,7 +227,7 @@ class OAuth2ClientSchema(ma.Schema):
     user_id = fields.String(required=True)
     client_id = fields.String(dump_only=True)
     client_secret = fields.String(dump_only=True)
-    issued_at = fields.Integer(dump_only=True)
+    client_id_issued_at = fields.Integer()
     expires_at = fields.Integer(dump_only=True)
     redirect_uri = fields.String()
     token_endpoint_auth_method = fields.String()

--- a/authserver/db/models/models.py
+++ b/authserver/db/models/models.py
@@ -227,7 +227,7 @@ class OAuth2ClientSchema(ma.Schema):
     user_id = fields.String(required=True)
     client_id = fields.String(dump_only=True)
     client_secret = fields.String(dump_only=True)
-    client_id_issued_at = fields.Integer()
+    client_id_issued_at = fields.Integer(dump_only=True)
     expires_at = fields.Integer(dump_only=True)
     redirect_uri = fields.String()
     token_endpoint_auth_method = fields.String()

--- a/tests/api/test_all_apis.py
+++ b/tests/api/test_all_apis.py
@@ -8,7 +8,7 @@ demonstrating how to interact with the various APIs.
 import pytest
 import json
 from flask import Response
-from expects import expect, be, equal, raise_error, be_above_or_equal, contain
+from expects import expect, be, equal, raise_error, be_above, be_above_or_equal, contain
 from authserver.db import db, DataTrust, User
 
 DATA_TRUST = {
@@ -196,12 +196,13 @@ class TestAllAPIs(object):
                 '/clients/{}'.format(client_id), data=json.dumps(request_body), headers=headers)
             expect(response.status_code).to(equal(200))
 
-        # Ensure that clients actually have roles and users
+        # Ensure that clients actually have roles, users, and other crucial fields
         for client_id in client_ids:
             response = client.get(
                 '/clients/{}'.format(client_id), headers=headers)
             result = response.json['response']
             expect(result['id']).to(equal(client_id))
+            expect(result['client_id_issued_at']).to(be_above(0))
             expect(user_ids).to(contain(result['user_id']))
             expect(len(result['roles'])).to(equal(len(role_ids)))
 


### PR DESCRIPTION
# Description
This PR accommodates the newest version of the OAuth2ClientMixin. This entails:

1. Use `client_id_issued_at` (as opposed to `issued_at`) in [the client schema](https://github.com/brighthive/authserver/pull/27/files#diff-194e84de2da35abb55f4dd25619b2f72). This follows the field definition in the latest version of the OAuth2ClientMixin.
2. Set the value of [`client_id_issued_at` when POSTing a new client](https://github.com/brighthive/authserver/pull/27/files#diff-1af24dd91480ed306dee10446d08c5e3). This is necessary, since the the new OAuth2ClientMixin uses 0 as the default. 

Deprecated OAuth2ClientMixin: https://github.com/lepture/authlib/blob/64390bfa02f14923e2dd1150d2775f1782bcf166/authlib/flask/oauth2/sqla.py#L22-L24

Latest OAuth2ClientMixin:
https://github.com/lepture/authlib/blob/64390bfa02f14923e2dd1150d2775f1782bcf166/authlib/integrations/sqla_oauth2/client_mixin.py#L11