### PR TITLE
fix: Pluralize redirect_uris per OAuth2 expectations

### DIFF
--- a/authserver/db/models/models.py
+++ b/authserver/db/models/models.py
@@ -229,7 +229,7 @@ class OAuth2ClientSchema(ma.Schema):
     client_secret = fields.String(dump_only=True)
     client_id_issued_at = fields.Integer(dump_only=True)
     expires_at = fields.Integer(dump_only=True)
-    redirect_uri = fields.String()
+    redirect_uris = fields.List(fields.String())
     token_endpoint_auth_method = fields.String()
     grant_type = fields.String()
     response_type = fields.String()


### PR DESCRIPTION
# Description
This PR updates the `OAuth2ClientSchema` to pluralize `redirect_uris` per the expectations of the `OAuth2ClientMixin`. See the source:
https://github.com/lepture/authlib/blob/1d181dd67b08880d284298265942d9af5f7a8acd/authlib/integrations/sqla_oauth2/client_mixin.py#L38-L40