### PR TITLE
chore: Remove capital 'H' from Brighthive

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright © `2019` `BrightHive`
+Copyright © `2019` `Brighthive`
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BrightHive Authorization and Authentication Server [![Documentation Status](https://readthedocs.org/projects/brighthive-authserver/badge/?version=latest)](https://brighthive-authserver.readthedocs.io/en/latest/?badge=latest)
+# Brighthive Authorization and Authentication Server [![Documentation Status](https://readthedocs.org/projects/brighthive-authserver/badge/?version=latest)](https://brighthive-authserver.readthedocs.io/en/latest/?badge=latest)
 
 An OAuth 2.0 server with added services for providing fine-grain access control to Data Trust assets.
 
@@ -6,24 +6,18 @@ An OAuth 2.0 server with added services for providing fine-grain access control 
 
 ### Visual Studio Code Configuration
 
-Most BrightHive engineers use [Visual Studio Code](https://code.visualstudio.com/) as their primary IDE. Below is a basic configuration that will work for this application.
+Most Brighthive engineers use [Visual Studio Code](https://code.visualstudio.com/) as their primary IDE. Below is a basic configuration that will work for this application.
 
 ```json
 {
-    "python.pythonPath": "/path/to/python",
-    "python.linting.pycodestyleEnabled": true,
-    "python.linting.pycodestylePath": "pycodestyle",
-    "python.formatting.autopep8Path": "autopep8",
-    "python.linting.pycodestyleArgs": [
-        "--ignore=E501,E0239"
-    ],
-    "python.formatting.autopep8Args": [
-        "--ignore=E501,E0239"
-    ],
-    "python.linting.pylintEnabled": false,
-    "python.linting.enabled": true,
-    "python.analysis.disabled": [
-        "inherit-non-class"
-    ]
+  "python.pythonPath": "/path/to/python",
+  "python.linting.pycodestyleEnabled": true,
+  "python.linting.pycodestylePath": "pycodestyle",
+  "python.formatting.autopep8Path": "autopep8",
+  "python.linting.pycodestyleArgs": ["--ignore=E501,E0239"],
+  "python.formatting.autopep8Args": ["--ignore=E501,E0239"],
+  "python.linting.pylintEnabled": false,
+  "python.linting.enabled": true,
+  "python.analysis.disabled": ["inherit-non-class"]
 }
 ```

--- a/authserver/api/templates/authorize.html
+++ b/authserver/api/templates/authorize.html
@@ -7,7 +7,7 @@
     <div class="form-check form-check-inline">
         <input type="checkbox" class="form-check-input" id="consentCheckbox" name="consent">
         <label class="form-check-label ml-2" for="consentCheckbox">
-            I agree that <strong>BrightHive</strong> can use information from my BrightHive Authserver account to create custom views visible only to me (such as a user profile).
+            I agree that <strong>Brighthive</strong> can use information from my Brighthive Authserver account to create custom views visible only to me (such as a user profile).
         </label>
     </div>
     <button class="mt-5 btn btn-primary btn-lg" type="submit">Continue</button>

--- a/authserver/api/templates/base.html
+++ b/authserver/api/templates/base.html
@@ -18,14 +18,14 @@
     <link rel="stylesheet" href="{{ url_for('oauth2_ep.static', filename='css/bootstrap.min.css') }}">
     <link rel="stylesheet" href="{{ url_for('oauth2_ep.static', filename='css/style.css') }}">
     <link rel="shortcut icon" href="{{ url_for('oauth2_ep.static', filename='favicon.ico') }}">
-    <title>BrightHive Authorization and Authentication Service</title>
+    <title>Brighthive Authorization and Authentication Service</title>
 </head>
 
 <body>
     <div class="login">
         <img class="img-fluid img-max" 
         src="{{ url_for('oauth2_ep.static', filename='images/logo.svg')}}"
-        alt="BrightHive Logo">
+        alt="Brighthive Logo">
         {% block content %}
         {% endblock %}
     </div>

--- a/authserver/config/settings.json
+++ b/authserver/config/settings.json
@@ -1,5 +1,5 @@
 {
-    "api_name": "BrightHive Auth Server",
+    "api_name": "Brighthive Auth Server",
     "api_description": "An OAuth 2.0 server with an added mechanism for providing fine-grain access control to Data Trust assets.",
     "api_version": "1.0.0"
 }

--- a/authserver/oauth2/__init__.py
+++ b/authserver/oauth2/__init__.py
@@ -1,1 +1,1 @@
-from authserver.oauth2.rfc6749 import BrightHiveAuthorizationServer, authenticate_client_secret_json
+from authserver.oauth2.rfc6749 import BrighthiveAuthorizationServer, authenticate_client_secret_json

--- a/authserver/oauth2/rfc6749/__init__.py
+++ b/authserver/oauth2/rfc6749/__init__.py
@@ -1,2 +1,2 @@
 from authserver.oauth2.rfc6749.authenticate_client import authenticate_client_secret_json
-from authserver.oauth2.rfc6749.authorization_server import BrightHiveAuthorizationServer
+from authserver.oauth2.rfc6749.authorization_server import BrighthiveAuthorizationServer

--- a/authserver/oauth2/rfc6749/authorization_server.py
+++ b/authserver/oauth2/rfc6749/authorization_server.py
@@ -1,4 +1,4 @@
-"""BrightHive OAuth 2.0 Authorization Server.
+"""Brighthive OAuth 2.0 Authorization Server.
 
 """
 
@@ -9,8 +9,8 @@ from authlib.common.encoding import to_unicode
 from authlib.oauth2.rfc6749 import InvalidGrantError, OAuth2Error
 
 
-class BrightHiveAuthorizationServer(AuthorizationServer):
-    """BrightHive Authorization Server.
+class BrighthiveAuthorizationServer(AuthorizationServer):
+    """Brighthive Authorization Server.
 
     Overrides the base Authlib AuthorizationServer class to provide a custom method
     for passing the OAuth 2.0 grant type as a field in the JSON request body, but still

--- a/authserver/utilities/oauth2.py
+++ b/authserver/utilities/oauth2.py
@@ -23,12 +23,13 @@ from authlib.oauth2.rfc6749 import grants
 from authlib.oauth2.rfc7636 import CodeChallenge
 from authlib.integrations.flask_oauth2 import AuthorizationServer
 from werkzeug.security import gen_salt
-from authserver.oauth2 import BrightHiveAuthorizationServer, authenticate_client_secret_json
+from authserver.oauth2 import BrighthiveAuthorizationServer, authenticate_client_secret_json
 from authserver.db import db, User, OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
 
 
 class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
-    TOKEN_ENDPOINT_AUTH_METHODS = ['client_secret_basic', 'client_secret_post', 'none']
+    TOKEN_ENDPOINT_AUTH_METHODS = [
+        'client_secret_basic', 'client_secret_post', 'none']
 
     def create_authorization_code(self, client, grant_user, request):
         code = gen_salt(48)
@@ -87,7 +88,7 @@ class ClientCredentialsGrant(grants.ClientCredentialsGrant):
 
 query_client = create_query_client_func(db.session, OAuth2Client)
 save_token = create_save_token_func(db.session, OAuth2Token)
-authorization = BrightHiveAuthorizationServer(
+authorization = BrighthiveAuthorizationServer(
     query_client=query_client,
     save_token=save_token,
 )
@@ -101,7 +102,8 @@ def config_oauth(app):
 
     # supported grant types
     authorization.register_grant(ClientCredentialsGrant)
-    authorization.register_grant(AuthorizationCodeGrant, [CodeChallenge(required=False)])
+    authorization.register_grant(AuthorizationCodeGrant, [
+                                 CodeChallenge(required=False)])
 
     # support revocation
     revocation_cls = create_revocation_endpoint(db.session, OAuth2Token)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,8 +17,8 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'BrightHive Auth Server'
-copyright = '2019, BrightHive'
+project = 'Brighthive Auth Server'
+copyright = '2019, Brighthive'
 author = 'Gregory Mundy'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,12 @@
-.. BrightHive Auth Server documentation master file, created by
+.. Brighthive Auth Server documentation master file, created by
    sphinx-quickstart on Mon Jul 22 19:06:12 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-BrightHive Authorization and Authentication Server
+Brighthive Authorization and Authentication Server
 ===================================================
 
-Welcome to the official documentation for BrightHive's Authorization and
+Welcome to the official documentation for Brighthive's Authorization and
 Authentication Server (herein referred to as `AuthServer`). The primary goals
 of this document is to provide background information about AuthServer as well
 as serve as a field guide for application developers who need to integrate with


### PR DESCRIPTION
# Description

This PR removes the big "H" from Brighthive to align with our new branding.