### PR TITLE
Add support for neo4j secure connection

### DIFF
--- a/authserver/config/config.py
+++ b/authserver/config/config.py
@@ -56,6 +56,7 @@ class AbstractConfiguration(ABC):
         self.graph_db_hostname = os.getenv('GRAPH_DB_HOSTNAME', 'localhost')
         self.graph_db_port = os.getenv('GRAPH_DB_PORT', '7687')
         self.graph_db_encrypted = os.getenv('GRAPH_DB_ENCRYPTED', 'false').upper() == 'TRUE'
+        self.neo4j_production = os.getenv("NEO4J_PRODUCTION", "False").upper() == 'TRUE'
 
         self.sendgrid_api_key = os.getenv('SENDGRID_API_KEY', 'apikey')
         self.sendgrid_from_email = os.getenv('SENDGRID_FROM_EMAIL', 'user@example.com')
@@ -80,6 +81,8 @@ class AbstractConfiguration(ABC):
 
     @property
     def graph_db_connection_uri(self):
+        if self.neo4j_production:
+            return f'neo4j+s://{self.graph_db_hostname}'
         return f'bolt://{self.graph_db_hostname}:{self.graph_db_port}'
 
 

--- a/authserver/db/graph_database.py
+++ b/authserver/db/graph_database.py
@@ -39,9 +39,13 @@ class Neo4jGraphDatabase(AbstractGraphDatabase):
     def connect(self):
         """Establish a connection to the Graph database."""
         if self._driver is None:
-            self._driver = GraphDatabase.driver(uri=self._config.graph_db_connection_uri,
-                                                auth=basic_auth(self._config.graph_db_user, self._config.graph_db_password),
-                                                encrypted=self._config.graph_db_encrypted)
+            if self._config.neo4j_production:
+                self._driver = GraphDatabase.driver(uri=self._config.graph_db_connection_uri,
+                                                    auth=(self._config.graph_db_user, self._config.graph_db_password))
+            else:
+                self._driver = GraphDatabase.driver(uri=self._config.graph_db_connection_uri,
+                                                    auth=basic_auth(self._config.graph_db_user, self._config.graph_db_password),
+                                                    encrypted=self._config.graph_db_encrypted)
 
         if not hasattr(g, 'graph_db'):
             g.graph_db = self._driver.session()


### PR DESCRIPTION
# Description

## JIRA ticket

[SE-138]

## Summary

Add a flag that allows the Neo4j IoC container understand how to connect to Neo4j Aura with the `neo4j+s` protocol.


# Checklists

### Basic

- [ ] Did you write tests for the code in this PR?
- [ ] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

### Frontend

- [ ] HTTP links should embed text that clearly explains what information your readers will find when they click on a hyperlink. [Read more about HTML accessibility](https://accessibility.umn.edu/core-skills/hyperlinks).

# Notes for the Reviewer

Not a major change, just add some conditional logic to allow for specifying when to use `neo4j+s` in the connection string and remove the basic auth connection.

[SE-138]: https://brighthiveio.atlassian.net/browse/SE-138