### PR TITLE
fix: Use exception response_handler in User Delete Exception, instead …

### DIFF
--- a/authserver/api/user.py
+++ b/authserver/api/user.py
@@ -146,8 +146,8 @@ class UserResource(Resource):
                 return self.response_handler.successful_delete_response('User', id, user_obj)
             else:
                 return self.response_handler.not_found_response(id)
-        except Exception:
-            return self.response_handler.not_found_response(id)
+        except Exception as e:
+            return self.response_handler.exception_response(exception_name=type(e).__name__)
 
     def _update(self, id: str, partial=True):
         """General update function for PUT and PATCH.

--- a/authserver/api/user.py
+++ b/authserver/api/user.py
@@ -137,17 +137,14 @@ class UserResource(Resource):
     def delete(self, id: str = None):
         if id is None:
             return self.response_handler.method_not_allowed_response()
-        try:
-            user = User.query.filter_by(id=id).first()
-            if user:
-                user_obj = self.user_schema.dump(user)
-                db.session.delete(user)
-                db.session.commit()
-                return self.response_handler.successful_delete_response('User', id, user_obj)
-            else:
-                return self.response_handler.not_found_response(id)
-        except Exception as e:
-            return self.response_handler.exception_response(exception_name=type(e).__name__)
+        user = User.query.filter_by(id=id).first()
+        if user:
+            user_obj = self.user_schema.dump(user)
+            db.session.delete(user)
+            db.session.commit()
+            return self.response_handler.successful_delete_response('User', id, user_obj)
+        else:
+            return self.response_handler.not_found_response(id)
 
     def _update(self, id: str, partial=True):
         """General update function for PUT and PATCH.

--- a/authserver/app/app.py
+++ b/authserver/app/app.py
@@ -81,10 +81,10 @@ def create_app(environment: str = None):
         return response
 
     def handle_errors(e):
-        print(f"""{e}, app.py, line 83""")
+        logging.info(f"""{e}, app.py, line 83""")
         response_body = ResponseBody()
         if isinstance(e, ValidationError):
-            print("ValidationError:")
+            logging.info("ValidationError:")
             return response_body.custom_response(status="Error", messages=[e.messages])
         else:
             try:

--- a/authserver/app/app.py
+++ b/authserver/app/app.py
@@ -120,7 +120,7 @@ def create_app(environment: str = None):
     app.register_blueprint(scope_bp)
     app.register_blueprint(password_recovery_bp)
 
-    app.register_error_handler(handle_errors)
+    app.register_error_handler(Exception, handle_errors)
 
     app.teardown_appcontext(teardown_appcontext)
 


### PR DESCRIPTION
…of a not found response (404)

# Description

## JIRA ticket

[SE-228]

## Summary

I am unable to DELETE Users via the Authserver API. I can GET the same User I am trying to DELETE via the same API with the same Auth Token, but a DELETE returns a 404:
```
{"status": "Error", "code": 404, "messages": ["No resource with identifier '95afbef10d584472bad5ad41f726e83b' found."]}
```

The change in this PR should return a more precise message about what is preventing the DELETE to work.


[SE-228]: https://brighthiveio.atlassian.net/browse/SE-228