### PR TITLE
feat: Add 'activate' option to user resource (Hive 1572)

### DIFF
--- a/authserver/api/user.py
+++ b/authserver/api/user.py
@@ -195,6 +195,7 @@ class UserResource(Resource):
 
         user.active = False
         user.can_login = False
+        user.date_last_updated = datetime.utcnow()
 
         clients = OAuth2Client.query.filter_by(user_id=user_id).all()
         for client in clients:
@@ -211,6 +212,7 @@ class UserResource(Resource):
 
         user.active = True
         user.can_login = True
+        user.date_last_updated = datetime.utcnow()
 
         clients = OAuth2Client.query.filter_by(user_id=user_id).all()
         for client in clients:

--- a/authserver/utilities/errors.py
+++ b/authserver/utilities/errors.py
@@ -1,0 +1,4 @@
+class RecordNotFoundError(Exception):
+    def __init__(self, record_id):
+        super().__init__()
+        self.record_id = record_id

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -6,7 +6,7 @@ services:
     environment: 
       - POSTGRES_DB=authserver
       - POSTGRES_USER=brighthive_admin
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_PASSWORD=passw0rd
     ports:
       - 5432:5432
   neo4j:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 
+MAX_RETRIES=5
+WORKERS=4
+RETRIES=0
+until flask db upgrade; do
+    RETRIES=`expr $RETRIES + 1`
+    if [[ "$RETRIES" -eq "$MAX_RETRIES" ]]; then
+        echo "Retry Limit Exceeded. Aborting..."
+        exit 1
+    fi
+    sleep 2
+done
+
 if [ "$APP_ENV" == "DEVELOPMENT" ] || [ -z "$APP_ENV" ]; then
     export AUTHLIB_INSECURE_TRANSPORT=1
     gunicorn -w 4 -b 0.0.0.0:8000 wsgi:app --reload --worker-class gevent --timeout 600
 else
-    MAX_RETRIES=5
-    WORKERS=4
-    RETRIES=0
-    until flask db upgrade; do
-        RETRIES=`expr $RETRIES + 1`
-        if [[ "$RETRIES" -eq "$MAX_RETRIES" ]]; then
-            echo "Retry Limit Exceeded. Aborting..."
-            exit 1
-        fi
-        sleep 2
-    done
     gunicorn -b 0.0.0.0 -w $WORKERS wsgi:app --worker-class gevent
 fi

--- a/tests/api/test_user_resource.py
+++ b/tests/api/test_user_resource.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from expects import be, be_above_or_equal, contain, equal, expect, raise_error
+from expects import be, be_above_or_equal, contain, equal, expect, raise_error, have_len
 from flask import Response
 from time import sleep
 
@@ -11,159 +11,221 @@ from tests.utils import post_users
 
 USERS = [
     {
-        'username': 'test-user-1',
-        'password': 'password',
-        'person_id': 'c0ffee-c0ffee-1',
-        'can_login': True
+        "username": "test-user-1",
+        "password": "password",
+        "person_id": "c0ffee-c0ffee-1",
+        "can_login": True,
     },
     {
-        'username': 'test-user-2',
-        'password': 'password',
-        'person_id': 'c0ffee-c0ffee-2',
-        'can_login': True
+        "username": "test-user-2",
+        "password": "password",
+        "person_id": "c0ffee-c0ffee-2",
+        "can_login": True,
     },
     {
-        'username': 'test-user-3',
-        'password': 'password',
-        'person_id': 'c0ffee-c0ffee-3',
-        'can_login': True
-    }
+        "username": "test-user-3",
+        "password": "password",
+        "person_id": "c0ffee-c0ffee-3",
+        "can_login": True,
+    },
 ]
 
 
 class TestUserResource:
     def test_user_api(self, client, token_generator):
         # Common headers go in this dict
-        headers = {'content-type': 'application/json',
-                   'authorization': f'bearer {token_generator.get_token(client)}'}
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"bearer {token_generator.get_token(client)}",
+        }
 
-        response = client.get('/users', headers=headers)
+        response = client.get("/users", headers=headers)
         response_data = response.json
         expect(response.status_code).to(be(200))
-        expect(len(response_data['response'])).to(equal(1))
+        expect(len(response_data["response"])).to(equal(1))
 
         # Populate database with users
         post_users(USERS, client, token_generator.get_token(client))
 
         # GET all users
-        response = client.get('/users', headers=headers)
+        response = client.get("/users", headers=headers)
         response_data = response.json
         expect(response.status_code).to(be(200))
-        expect(len(response_data['response'])).to(be_above_or_equal(3))
-        added_users = response_data['response']
+        expect(len(response_data["response"])).to(be_above_or_equal(3))
+        added_users = response_data["response"]
 
         # Store ID for all users since we will break the data.
         added_user_ids = []
         for user in added_users:
-            added_user_ids.append(user['id'])
+            added_user_ids.append(user["id"])
 
         # Attempt to POST an existing user
         response = client.post(
-            '/users', data=json.dumps(USERS[0]), headers=headers)
+            "/users", data=json.dumps(USERS[0]), headers=headers)
         expect(response.status_code).to(be_above_or_equal(400))
 
         # Get all users by ID
         for user in added_users:
             response = client.get(
-                '/users/{}'.format(user['id']), headers=headers)
+                "/users/{}".format(user["id"]), headers=headers)
             expect(response.status_code).to(be(200))
 
         # Update a user with a PATCH
-        user_id = added_users[len(added_users) - 1]['id']
+        user_id = added_users[len(added_users) - 1]["id"]
         new_person_id = str(
-            reversed(added_users[len(added_users) - 1]['person_id']))
-        single_field_update = {
-            'person_id': new_person_id
-        }
-        response = client.patch('/users/{}'.format(user_id),
-                                data=json.dumps(single_field_update), headers=headers)
+            reversed(added_users[len(added_users) - 1]["person_id"]))
+        single_field_update = {"person_id": new_person_id}
+        response = client.patch(
+            "/users/{}".format(user_id),
+            data=json.dumps(single_field_update),
+            headers=headers,
+        )
         expect(response.status_code).to(equal(200))
 
         # Rename a user with a PUT, expect to fail because not all fields specified
-        response = client.put('/users/{}'.format(user_id),
-                              data=json.dumps(single_field_update), headers=headers)
+        response = client.put(
+            "/users/{}".format(user_id),
+            data=json.dumps(single_field_update),
+            headers=headers,
+        )
         expect(response.status_code).to(equal(422))
 
         # Rename a user with a PUT, providing the entire object
         user_to_update = added_users[len(added_users) - 1]
-        user_to_update['password'] = 'password'
-        user_to_update.pop('role', None)
-        user_to_update.pop('date_created', None)
-        user_to_update.pop('id', None)
-        user_to_update.pop('date_last_updated', None)
+        user_to_update["password"] = "password"
+        user_to_update.pop("role", None)
+        user_to_update.pop("date_created", None)
+        user_to_update.pop("id", None)
+        user_to_update.pop("date_last_updated", None)
 
-        response = client.put('/users/{}'.format(user_id),
-                              data=json.dumps(user_to_update), headers=headers)
+        response = client.put(
+            "/users/{}".format(user_id),
+            data=json.dumps(user_to_update),
+            headers=headers,
+        )
         expect(response.status_code).to(equal(200))
 
-        # Ensure users have been deleted by the deletion of the data trust associated with them.
-        response = client.get('/users', headers=headers)
-        expect(response.status_code).to(be(200))
-        response_data = response.json
-
-        # Deactivate a user
-        headers = {'content-type': 'application/json',
-                   'authorization': f'bearer {token_generator.get_token(client)}'}
-        response = client.get('/users', headers=headers)
-
-        a_user_id = response.json['response'][1]['id']
-        associated_client_id = self._post_client(
-            client, a_user_id, token_generator)
-
-        user_to_deactivate = {
-            'id': a_user_id
-        }
-
-        # First, POST with an invalid argument
-        response = client.post('/users?action=not-a-valid-argument',
-                               data=json.dumps(user_to_deactivate), headers=headers)
-        expect(response.status_code).to(equal(422))
-
-        # Second, POST with an invalid user_id
-        response = client.post('/users?action=deactivate',
-                               data=json.dumps({'id': '123bad'}), headers=headers)
-        expect(response.status_code).to(equal(404))
-        expect(response.json['messages'][0]).to(
-            equal("No resource with identifier '123bad' found."))
-
-        # Finally, POST with a valid user_id
-        response = client.post('/users?action=deactivate',
-                               data=json.dumps(user_to_deactivate), headers=headers)
-        expect(response.status_code).to(equal(200))
-
-        response = client.get('/users/{}'.format(a_user_id), headers=headers)
-        expect(response.json['response']['active']).to(be(False))
-        expect(response.json['response']['can_login']).to(be(False))
-
-        response = client.get(
-            '/clients/{}'.format(associated_client_id), headers=headers)
-        expect(response.json['response']['client_secret']).to(be(None))
-
-        # Delete users and clients
-        response = client.delete(
-            f'/clients/{associated_client_id}', headers=headers)
-        expect(response.status_code).to(be(200))
+        # Delete users
         for user_id in added_user_ids:
             response = client.delete(f"/users/{user_id}", headers=headers)
             expect(response.status_code).to(be(200))
 
     def _post_client(self, client, user_id, token_generator):
-        headers = {'content-type': 'application/json',
-                   'authorization': f'bearer {token_generator.get_token(client)}'}
-        client_data = {
-            'client_name': 'test client 1',
-            'user_id': user_id
+        headers = {
+            "content-type": "application/json",
+            "authorization": f"bearer {token_generator.get_token(client)}",
         }
+        client_data = {"client_name": "test client 1", "user_id": user_id}
         response = client.post(
-            '/clients', data=json.dumps(client_data), headers=headers)
+            "/clients", data=json.dumps(client_data), headers=headers
+        )
         expect(response.status_code).to(equal(201))
 
-        return response.json['response'][0]['id']
+        return response.json["response"][0]["id"]
+
+
+class TestPOSTUserResource:
+    def test_post_user_invalid_action(self, mocker, client, user):
+        mocker.patch(
+            "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
+            return_value=True,
+        )
+
+        response = client.post(
+            "/users?action=not-a-valid-argument",
+            data=json.dumps({"id": user.id}),
+            headers={},
+        )
+
+        expect(response.status_code).to(equal(422))
+
+    def test_post_user_deactivate_invalid_user_id(self, mocker, client):
+        mocker.patch(
+            "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
+            return_value=True,
+        )
+
+        response = client.post(
+            "/users?action=deactivate", data=json.dumps({"id": "123bad"}), headers={}
+        )
+
+        expect(response.status_code).to(equal(404))
+        expect(response.json["messages"][0]).to(
+            equal("No resource with identifier '123bad' found.")
+        )
+
+    def test_post_user_deactivate(self, mocker, client, user, oauth_client):
+        mocker.patch(
+            "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
+            return_value=True,
+        )
+
+        response = client.post(
+            "/users?action=deactivate", data=json.dumps({"id": user.id}), headers={}
+        )
+        expect(response.status_code).to(equal(200))
+
+        # Assert that 'active' and 'can_login' have been toggled to 'False'
+        response = client.get("/users/{}".format(user.id), headers={})
+        expect(response.json["response"]["active"]).to(be(False))
+        expect(response.json["response"]["can_login"]).to(be(False))
+
+        # Assert that associated client no longer has a secret
+        response = client.get(
+            "/clients/{}".format(oauth_client.id), headers={})
+        expect(response.json["response"]["client_secret"]).to(be(None))
+
+        # Clean up (n.b., clean up should happen in the conftest – between each test.)
+        client.delete(f"/users/{user.id}", headers={})
+
+    def test_post_user_activate_invalid_user_id(self, mocker, client):
+        mocker.patch(
+            "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
+            return_value=True,
+        )
+
+        response = client.post(
+            "/users?action=activate", data=json.dumps({"id": "123bad"}), headers={}
+        )
+
+        expect(response.status_code).to(equal(404))
+        expect(response.json["messages"][0]).to(
+            equal("No resource with identifier '123bad' found.")
+        )
+
+    def test_post_user_reactivate(self, mocker, client, user, oauth_client):
+        mocker.patch(
+            "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
+            return_value=True,
+        )
+
+        response = client.post(
+            "/users?action=deactivate", data=json.dumps({"id": user.id}), headers={}
+        )
+        expect(response.status_code).to(equal(200))
+
+        # Activate user
+        response = client.post(
+            "/users?action=activate", data=json.dumps({"id": user.id}), headers={}
+        )
+        expect(response.status_code).to(equal(200))
+
+        # Assert that 'active' and 'can_login' have been toggled to 'True'
+        response = client.get("/users/{}".format(user.id), headers={})
+        expect(response.json["response"]["active"]).to(be(True))
+        expect(response.json["response"]["can_login"]).to(be(True))
+
+        # Assert that associated client has a secret
+        response = client.get(
+            '/clients/{}'.format(oauth_client.id), headers={})
+        expect(response.json['response']['client_secret']).to(have_len(48))
+
+        # Clean up (n.b., clean up should happen in the conftest – between each test.)
+        client.delete(f"/users/{user.id}", headers={})
 
 
 class TestDELETEUserResource:
-    def test_delete_user_with_client(self, mocker, client, token_generator):
-        # Common headers go in this dict
+    def test_delete_user_with_client(self, mocker, client):
         mocker.patch(
             "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
             return_value=True,
@@ -171,19 +233,16 @@ class TestDELETEUserResource:
 
         # Populate database with user
         user_data = USERS[0]
-        user_data['active'] = True
+        user_data["active"] = True
         response = client.post(
-            '/users', data=json.dumps(user_data), headers={})
-        user_id = response.json['response'][0]['id']
+            "/users", data=json.dumps(user_data), headers={})
+        user_id = response.json["response"][0]["id"]
 
         # Populate database with client
-        client_data = {
-            'client_name': 'test client 1',
-            'user_id': user_id
-        }
+        client_data = {"client_name": "test client 1", "user_id": user_id}
         response = client.post(
-            '/clients', data=json.dumps(client_data), headers={})
-        client_id = response.json['response'][0]['id']
+            "/clients", data=json.dumps(client_data), headers={})
+        client_id = response.json["response"][0]["id"]
 
         # Add entity to authorized_client
         _store_client_authorization(client_id=client_id, user_id=user_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,17 @@
 import json
 import os
 from time import sleep
+from uuid import uuid4
 
 import pytest
 import requests
 from flask import Response
 from flask_migrate import upgrade
+from werkzeug.security import gen_salt
 
 from authserver import create_app
 from authserver.config import ConfigurationFactory
-from authserver.db import User, db
+from authserver.db import db, User, OAuth2Client
 from authserver.utilities import PostgreSQLContainer
 
 
@@ -81,3 +83,33 @@ def environments():
         'SANDBOX',
         'PRODUCTION'
     ]
+
+
+@pytest.fixture
+def user():
+    data = {
+        "username": "greg_henry",
+        "password": "passw0rd!",
+        "can_login": True,
+        "active": True
+    }
+    user = User(**data)
+
+    db.session.add(user)
+
+    return user
+
+
+@pytest.fixture
+def oauth_client(user):
+    data = {
+        "id": str(uuid4()).replace('-', ''),
+        "user_id": user.id,
+        "client_id": gen_salt(24),
+        "client_secret": gen_salt(48)
+    }
+    oauth_client = OAuth2Client(**data)
+
+    db.session.add(oauth_client)
+
+    return oauth_client


### PR DESCRIPTION
# Description

## JIRA ticket

[HIVE-1572]

In service of FE ticket: https://brighthiveio.atlassian.net/browse/HIVE-1571

## Summary

This PR introduces an 'activate' action param to the User Resource: here, 'activate' means that the app toggles 'can_login' and 'active' to True, and the app reissues secrets to clients. 

1. POST to `{authserver_baseurl}/users?action=activate`.
2. The body of the POST should be:

```json
{ "id": "the-id-of-the-user-to-activate" }
```

# Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [x] Authorization has been implemented across these changes
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] Any web UI is escaping output (to prevent XSS)
- [x] Sensitive data has been identified and is being protected properly

# Notes for the Reviewer

None.


[HIVE-1572]: https://brighthiveio.atlassian.net/browse/HIVE-1572