### PR TITLE
feat: Expire and revoke deactivated user tokens (Hive 1298)

### DIFF
--- a/authserver/api/user.py
+++ b/authserver/api/user.py
@@ -197,6 +197,11 @@ class UserResource(Resource):
         user.can_login = False
         user.date_last_updated = datetime.utcnow()
 
+        token = OAuth2Token.query.filter_by(user_id=user.id).first()
+        if token:
+            token.revoked = True
+            token.expires_in = 0
+
         clients = OAuth2Client.query.filter_by(user_id=user_id).all()
         for client in clients:
             client.client_secret = None

--- a/authserver/api/user.py
+++ b/authserver/api/user.py
@@ -197,8 +197,8 @@ class UserResource(Resource):
         user.can_login = False
         user.date_last_updated = datetime.utcnow()
 
-        token = OAuth2Token.query.filter_by(user_id=user.id).first()
-        if token:
+        tokens = OAuth2Token.query.filter_by(user_id=user.id).all()
+        for token in tokens:
             token.revoked = True
             token.expires_in = 0
 

--- a/tests/api/test_user_resource.py
+++ b/tests/api/test_user_resource.py
@@ -154,7 +154,7 @@ class TestPOSTUserResource:
             equal("No resource with identifier '123bad' found.")
         )
 
-    def test_post_user_deactivate(self, mocker, client, user, oauth_client):
+    def test_post_user_deactivate(self, mocker, client, user, oauth_client, oauth_token):
         mocker.patch(
             "authlib.integrations.flask_oauth2.ResourceProtector.acquire_token",
             return_value=True,
@@ -174,6 +174,10 @@ class TestPOSTUserResource:
         response = client.get(
             "/clients/{}".format(oauth_client.id), headers={})
         expect(response.json["response"]["client_secret"]).to(be(None))
+
+        # Assert that the user's token has been revoked and expired
+        expect(oauth_token.revoked).to(be(True))
+        expect(oauth_token.is_access_token_expired()).to(be(True))
 
         # Clean up (n.b., clean up should happen in the conftest – between each test.)
         client.delete(f"/users/{user.id}", headers={})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from time import sleep
+from time import sleep, time
 from uuid import uuid4
 
 import pytest
@@ -13,7 +13,7 @@ from werkzeug.security import gen_salt
 
 from authserver import create_app
 from authserver.config import ConfigurationFactory
-from authserver.db import db, User, OAuth2Client
+from authserver.db import db, User, OAuth2Client, OAuth2Token
 from authserver.utilities import PostgreSQLContainer
 
 
@@ -113,3 +113,18 @@ def oauth_client(user):
     db.session.add(oauth_client)
 
     return oauth_client
+
+
+@pytest.fixture
+def oauth_token(user):
+    data = {
+        "access_token": str(uuid4()).replace("-", ""),
+        "issued_at": int(time()) - 865000,
+        "expires_in": 965000,
+        "user_id": user.id
+    }
+    token = OAuth2Token(**data)
+
+    db.session.add(token)
+
+    return token


### PR DESCRIPTION
# Description

## JIRA ticket

Handles backend for: [HIVE-1298]

## Summary

This PR adds a step to the deactivate function: find all user tokens and expire (and revoke) them.

# Checklists

### Basic

- [x] Did you write tests for the code in this PR?
- [x] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [x] Authorization has been implemented across these changes
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] Any web UI is escaping output (to prevent XSS)
- [x] Sensitive data has been identified and is being protected properly

# Notes for the Reviewer

Corresponding frontend PR: https://github.com/brighthive/facet/pull/570

Additional frontend work will happen in this ticket: https://brighthiveio.atlassian.net/browse/HIVE-1609


[HIVE-1298]: https://brighthiveio.atlassian.net/browse/HIVE-1298