### PR TITLE
Allow m2m creds to have super admin jwt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Hurrah! Check the app status here: `http://0.0.0.0:10001/health`
 APP_ENV=test pipenv run pytest
 ```
 
+## Machine to machine admin credentials
+
+To give a machine to machine credentials admin rights, you must manually enable it. There are no endpoints. This was done because super admin credentials are dangerous. In the `oauth2_clients` table you will find a `grant_super_admin` column. Set this to `True`.
+
 ### Visual Studio Code Configuration
 
 Most Brighthive engineers use [Visual Studio Code](https://code.visualstudio.com/) as their primary IDE. Below is a basic configuration that will work for this application.

--- a/authserver/db/models/models.py
+++ b/authserver/db/models/models.py
@@ -172,6 +172,7 @@ class OAuth2Client(db.Model, OAuth2ClientMixin):
     user_id = db.Column(
         db.String, db.ForeignKey('users.id', ondelete='CASCADE'))
     user = db.relationship('User')
+    grant_super_admin = db.Column(db.Boolean)
     roles = db.relationship('Role', secondary=roles, lazy='subquery',
                             backref=db.backref('clients', lazy=True))
 
@@ -233,6 +234,10 @@ class OAuth2Token(db.Model, OAuth2TokenMixin):
     user_id = db.Column(
         db.String, db.ForeignKey('users.id', ondelete='CASCADE'))
     user = db.relationship('User')
+    client_id = db.Column(
+        db.String(48), db.ForeignKey('oauth2_clients.client_id', ondelete='CASCADE'))
+    client = db.relationship('OAuth2Client')
+    
 
     def is_access_token_expired(self):
         expires_at = self.get_expires_at()

--- a/migrations/versions/631f37f8c085_add_superadmin_column_to_client.py
+++ b/migrations/versions/631f37f8c085_add_superadmin_column_to_client.py
@@ -1,0 +1,24 @@
+"""Add superadmin column to client.
+
+Revision ID: 631f37f8c085
+Revises: c43ffe7b4001
+Create Date: 2021-06-11 12:52:04.459481
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '631f37f8c085'
+down_revision = 'c43ffe7b4001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('oauth2_clients', sa.Column('grant_super_admin', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('oauth2_clients', 'grant_super_admin')


### PR DESCRIPTION
# Description

## JIRA ticket

[HIVE-1770]

## Summary

Enables clients to set a super admin value. This allows clients without users ( client credentials grant ) to successfully get a JWT and access token.

Previously this would break with the e2e platform scripts ( https://github.com/brighthive/platform-e2e-testing/pull/17 ) because client credentials does not have a user nor person associated, and the JWT process required a person id.

# Checklists

### Basic

- [ ] Did you write tests for the code in this PR?
- [ ] Did you document your changes in the README and/or in docstrings (as needed)?

### Security

- [ ] Authorization has been implemented across these changes
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Any web UI is escaping output (to prevent XSS)
- [ ] Sensitive data has been identified and is being protected properly

### Frontend

- [ ] HTTP links should embed text that clearly explains what information your readers will find when they click on a hyperlink. [Read more about HTML accessibility](https://accessibility.umn.edu/core-skills/hyperlinks).

# Notes for the Reviewer

A precise explanation of what the PR reviewer needs to evaluate. This might be:

- a low-level code review of certain functions
- a high-level assessment of strategy or architecture
- a confirmation that the code behaves as expected on another machine


[HIVE-1770]: https://brighthiveio.atlassian.net/browse/HIVE-1770